### PR TITLE
Update analyzer version

### DIFF
--- a/package/inject_generator/pubspec.yaml
+++ b/package/inject_generator/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.34.0
+  analyzer: ^0.36.3
   build: ^1.0.0
   code_builder: ^3.0.3
   collection: ^1.14.7


### PR DESCRIPTION
The latest version of the  **`build_runner`** is incompatible with the analyzer version.
Bumping it to **`0.36.3`**.